### PR TITLE
Add FastAPI wrapper for OData service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # openapi-odata
-Odata to open api 
+
+This project exposes an OData service as a FastAPI application. The server reads
+the OData `$metadata` document, dynamically creates Pydantic models and
+endpoints for each entity set, and exposes them via a generated OpenAPI 3.1
+schema.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Provide environment variables:
+   - `ODATA_SERVICE_URL` – base URL of the OData service.
+   - `ODATA_USERNAME` and `ODATA_PASSWORD` – credentials for basic auth.
+   - `ODATA_METADATA_FILE` – optional path to a local `$metadata` XML file.
+
+3. Run the server:
+   ```bash
+   uvicorn app.main:app
+   ```
+
+The generated OpenAPI document is available at `/openapi.json`.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,126 @@
+import os
+from typing import Any, Dict, List, Optional, Tuple
+from datetime import datetime
+
+import requests
+from fastapi import FastAPI, HTTPException
+from fastapi.openapi.utils import get_openapi
+from pydantic import BaseModel, create_model
+import pyodata
+
+ODATA_SERVICE_URL = os.getenv("ODATA_SERVICE_URL", "http://example.com/odata/")
+ODATA_USERNAME = os.getenv("ODATA_USERNAME", "user")
+ODATA_PASSWORD = os.getenv("ODATA_PASSWORD", "password")
+
+session = requests.Session()
+session.auth = (ODATA_USERNAME, ODATA_PASSWORD)
+
+# Fetch metadata. In restricted environments this may not work if the URL is not reachable
+# so we allow loading metadata from a local file via ODATA_METADATA_FILE.
+metadata_file = os.getenv("ODATA_METADATA_FILE")
+if metadata_file:
+    with open(metadata_file, "rb") as f:
+        metadata_bytes = f.read()
+else:
+    resp = session.get(ODATA_SERVICE_URL.rstrip("/") + "/$metadata")
+    resp.raise_for_status()
+    metadata_bytes = resp.content
+
+client = pyodata.Client(ODATA_SERVICE_URL, session, metadata=metadata_bytes)
+
+app = FastAPI(openapi_version="3.1.0")
+
+# Mapping from OData EDM primitive types to Python types
+TYPE_MAP = {
+    "Edm.String": str,
+    "Edm.Int32": int,
+    "Edm.Int16": int,
+    "Edm.Int64": int,
+    "Edm.Double": float,
+    "Edm.Single": float,
+    "Edm.Decimal": float,
+    "Edm.Boolean": bool,
+    "Edm.DateTime": datetime,
+}
+
+models: Dict[str, BaseModel] = {}
+
+for entity_set in client.schema.entity_sets:
+    etype = entity_set.entity_type
+    fields: Dict[str, Tuple[Any, Any]] = {}
+    for prop in etype.proprties():
+        py_type = TYPE_MAP.get(prop.typ.name, Any)
+        if prop.nullable:
+            py_type = Optional[py_type]
+        default = None if prop.nullable else ...
+        fields[prop.name] = (py_type, default)
+    model = create_model(etype.name, **fields)
+    models[entity_set.name] = model
+
+    def make_list_entities(name: str, mdl: BaseModel):
+        @app.get(f"/{name}", response_model=List[mdl], name=f"get_{name}")
+        def list_entities() -> List[mdl]:
+            url = ODATA_SERVICE_URL.rstrip("/") + f"/{name}"
+            resp = session.get(url)
+            if resp.status_code != 200:
+                raise HTTPException(resp.status_code, resp.text)
+            return resp.json().get("value", [])
+        return list_entities
+
+    def make_create_entity(name: str, mdl: BaseModel):
+        @app.post(f"/{name}", response_model=mdl, name=f"create_{name}")
+        def create_entity(item: mdl) -> mdl:
+            url = ODATA_SERVICE_URL.rstrip("/") + f"/{name}"
+            resp = session.post(url, json=item.model_dump(exclude_none=True))
+            if resp.status_code not in (200, 201):
+                raise HTTPException(resp.status_code, resp.text)
+            return resp.json()
+        return create_entity
+
+    def make_get_entity(name: str, mdl: BaseModel):
+        @app.get(f"/{name}/{{key}}", response_model=mdl, name=f"get_{name}_by_key")
+        def get_entity(key: str) -> mdl:
+            url = ODATA_SERVICE_URL.rstrip("/") + f"/{name}({key})"
+            resp = session.get(url)
+            if resp.status_code != 200:
+                raise HTTPException(resp.status_code, resp.text)
+            return resp.json()
+        return get_entity
+
+    def make_update_entity(name: str, mdl: BaseModel):
+        @app.patch(f"/{name}/{{key}}", response_model=mdl, name=f"update_{name}")
+        def update_entity(key: str, item: mdl) -> mdl:
+            url = ODATA_SERVICE_URL.rstrip("/") + f"/{name}({key})"
+            resp = session.patch(url, json=item.model_dump(exclude_none=True))
+            if resp.status_code != 204:
+                raise HTTPException(resp.status_code, resp.text)
+            resp = session.get(url)
+            resp.raise_for_status()
+            return resp.json()
+        return update_entity
+
+    def make_delete_entity(name: str):
+        @app.delete(f"/{name}/{{key}}", name=f"delete_{name}")
+        def delete_entity(key: str):
+            url = ODATA_SERVICE_URL.rstrip("/") + f"/{name}({key})"
+            resp = session.delete(url)
+            if resp.status_code not in (200, 204):
+                raise HTTPException(resp.status_code, resp.text)
+            return {"deleted": True}
+        return delete_entity
+
+    make_list_entities(entity_set.name, model)
+    make_create_entity(entity_set.name, model)
+    make_get_entity(entity_set.name, model)
+    make_update_entity(entity_set.name, model)
+    make_delete_entity(entity_set.name)
+
+@app.get("/openapi.json", include_in_schema=False)
+def custom_openapi():
+    schema = get_openapi(
+        title="OData Converted Service",
+        version="1.0.0",
+        routes=app.routes,
+    )
+    return schema
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pyodata
+openapi-spec-validator
+requests

--- a/sample_metadata.xml
+++ b/sample_metadata.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx">
+  <edmx:DataServices m:DataServiceVersion="2.0" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+    <Schema Namespace="ODataDemo" xmlns="http://schemas.microsoft.com/ado/2008/09/edm">
+      <EntityType Name="Product">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="ReleaseDate" Type="Edm.DateTime" Nullable="false" />
+        <Property Name="DiscontinuedDate" Type="Edm.DateTime" Nullable="true" />
+        <Property Name="Rating" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Price" Type="Edm.Double" Nullable="false" />
+      </EntityType>
+      <EntityContainer Name="DemoService" m:IsDefaultEntityContainer="true">
+        <EntitySet Name="Products" EntityType="ODataDemo.Product" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/validate_openapi.py
+++ b/validate_openapi.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from openapi_spec_validator import validate_spec
+from app.main import app
+
+client = TestClient(app)
+resp = client.get("/openapi.json")
+resp.raise_for_status()
+validate_spec(resp.json())
+print("OpenAPI schema is valid")


### PR DESCRIPTION
## Summary
- implement dynamic FastAPI server in `app/main.py`
- add a sample OData metadata file
- add validation script and requirements
- update README with usage instructions

## Testing
- `pip install -r requirements.txt`
- `ODATA_METADATA_FILE=sample_metadata.xml python validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_e_687ff9902e44832b96b3d27a2a882573