### PR TITLE
Add metadata fetch helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ parsed at runtime to create Pydantic models and routes.
    You can override the location with the `METADATA_XML_FILE` environment
    variable. The target backend URL can be customised via `ODATA_BASE_URL`.
 
+   You can fetch the XML from a running OData service using the
+   `fetch_metadata.py` helper:
+
+   ```bash
+   python fetch_metadata.py SERVICE_NAME --base-url https://host.example.com \
+       --output sample_metadata.xml --username USER --password PASS
+   ```
+
+   The script constructs `BASE_URL/SERVICE_NAME/$metadata` and performs a GET
+   request using Basic authentication. Environment variables `ODATA_BASE_URL`,
+   `ODATA_USERNAME` and `ODATA_PASSWORD` may also be used instead of passing the
+   corresponding options.
+
 3. Provide credentials in an `.env` file or environment variables:
    - `ODATA_USERNAME` and `ODATA_PASSWORD` – Basic Auth credentials.
 

--- a/fetch_metadata.py
+++ b/fetch_metadata.py
@@ -1,0 +1,40 @@
+import argparse
+import os
+import requests
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download OData service metadata")
+    parser.add_argument("service", help="Name of the OData service")
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("ODATA_BASE_URL", "http://example.com"),
+        help="Base URL of the OData system",
+    )
+    parser.add_argument(
+        "--output",
+        default="sample_metadata.xml",
+        help="Path to save the downloaded XML",
+    )
+    parser.add_argument(
+        "--username",
+        default=os.getenv("ODATA_USERNAME", "user"),
+        help="Basic auth username",
+    )
+    parser.add_argument(
+        "--password",
+        default=os.getenv("ODATA_PASSWORD", "password"),
+        help="Basic auth password",
+    )
+    args = parser.parse_args()
+
+    url = f"{args.base_url.rstrip('/')}/{args.service.strip('/')}/$metadata"
+    resp = requests.get(url, auth=(args.username, args.password))
+    resp.raise_for_status()
+    with open(args.output, "w", encoding="utf-8") as fh:
+        fh.write(resp.text)
+    print(f"Metadata saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `fetch_metadata.py` for downloading service metadata via basic auth
- document the helper script usage in the README

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `python validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_e_68826e3026fc832ba02947edcaf2e419