### PR TITLE
Fix entity lookup by entity set

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -39,7 +39,14 @@ def _build_model(name: str, props: List[Dict[str, Any]], complex_models: Dict[st
 
 
 def build_models(metadata: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
-    """Create Pydantic models for all complex and entity types."""
+    """Create Pydantic models for all complex and entity types.
+
+    The returned dictionary contains three keys:
+
+    ``entities`` -- models keyed by entity type name
+    ``entity_sets`` -- models keyed by entity set name
+    ``complex`` -- models keyed by complex type name
+    """
 
     complex_models: Dict[str, Type[BaseModel]] = {}
     for ct in metadata.get("complex_types", []):
@@ -53,4 +60,11 @@ def build_models(metadata: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
             "keys": et.get("keys", []),
         }
 
-    return {"entities": entity_models, "complex": complex_models}
+    set_models: Dict[str, Dict[str, Any]] = {}
+    for es in metadata.get("entity_sets", []):
+        et_name = es.get("entity_type")
+        et_model = entity_models.get(et_name)
+        if et_model:
+            set_models[es["name"]] = et_model
+
+    return {"entities": entity_models, "entity_sets": set_models, "complex": complex_models}

--- a/app/router.py
+++ b/app/router.py
@@ -64,7 +64,8 @@ def tools(service: str) -> Any:
 def schema(service: str) -> Any:
     ctx = get_context(service)
     entity_models = {
-        name: model_info["model"].schema() for name, model_info in ctx.models["entities"].items()
+        name: model_info["model"].schema()
+        for name, model_info in ctx.models["entities"].items()
     }
     return entity_models
 
@@ -72,7 +73,7 @@ def schema(service: str) -> Any:
 @router.get("/{service}/{entity}")
 def list_entities(service: str, entity: str, request: Request) -> Any:
     ctx = get_context(service)
-    if entity not in ctx.models["entities"]:
+    if entity not in ctx.models.get("entity_sets", {}):
         raise HTTPException(404, "Unknown entity")
     params = dict(request.query_params)
     return ctx.invoker.get(f"/{entity}", params)
@@ -81,7 +82,7 @@ def list_entities(service: str, entity: str, request: Request) -> Any:
 @router.get("/{service}/{entity}({keys})")
 def get_entity(service: str, entity: str, keys: str, request: Request) -> Any:
     ctx = get_context(service)
-    if entity not in ctx.models["entities"]:
+    if entity not in ctx.models.get("entity_sets", {}):
         raise HTTPException(404, "Unknown entity")
     params = dict(request.query_params)
     return ctx.invoker.get(f"/{entity}({keys})", params)
@@ -90,7 +91,7 @@ def get_entity(service: str, entity: str, keys: str, request: Request) -> Any:
 @router.get("/{service}/{entity}({keys})/{nav}")
 def navigate(service: str, entity: str, keys: str, nav: str, request: Request) -> Any:
     ctx = get_context(service)
-    if entity not in ctx.models["entities"]:
+    if entity not in ctx.models.get("entity_sets", {}):
         raise HTTPException(404, "Unknown entity")
     params = dict(request.query_params)
     return ctx.invoker.get(f"/{entity}({keys})/{nav}", params)


### PR DESCRIPTION
## Summary
- map entity set names to entity models when building models
- validate entity names against entity sets in router

## Testing
- `python validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_e_688283225194832ba65c41ca16a2d8d3