### PR TITLE
Fix missing base URL handling

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -76,7 +76,12 @@ def fetch_service(service: str) -> Optional[Dict[str, Any]]:
     )
     row = cur.fetchone()
     if row:
-        return dict(row)
+        data = dict(row)
+        if not data.get("base_url"):
+            data["base_url"] = os.getenv(
+                f"BASE_URL_{service.upper()}", os.getenv("BASE_URL", "")
+            )
+        return data
     return None
 
 

--- a/app/invoker.py
+++ b/app/invoker.py
@@ -10,6 +10,10 @@ class BackendInvoker:
     """Thin wrapper around :mod:`requests` with Basic Auth."""
 
     def __init__(self, base_url: str, username: str, password: str):
+        if not base_url:
+            raise ValueError("Backend base URL is not configured")
+        if not base_url.startswith(("http://", "https://")):
+            base_url = "http://" + base_url
         self.base_url = base_url.rstrip("/")
         self.session = requests.Session()
         self.session.auth = (username, password)


### PR DESCRIPTION
## Summary
- handle missing `base_url` when loading services from SQLite
- validate/normalize `base_url` in `BackendInvoker`

## Testing
- `python validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_e_68828740f4bc832b99c594010ae85e59