### PR TITLE
Fix credential handling for backend requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This project implements a small MCP style bridge that exposes OData services via
 3. Provide credentials in an `.env` file or environment variables:
    - `USERNAME` and `PASSWORD` – Basic Auth credentials for the backend
    - `BASE_URL` (optional) – default backend base URL
+   
+   **Note:** The server refuses to start if `USERNAME`/`PASSWORD` (or `ODATA_USERNAME`/`ODATA_PASSWORD`) are not defined. Ensure these values are set either in the environment or in an `.env` file.
 
 4. Run the server:
    ```bash

--- a/app/invoker.py
+++ b/app/invoker.py
@@ -35,6 +35,8 @@ def create_invoker(base_url: str) -> BackendInvoker:
     """Create an invoker using credentials from ``.env`` or environment."""
 
     load_dotenv()
-    username = os.getenv("USERNAME", os.getenv("ODATA_USERNAME", "user"))
-    password = os.getenv("PASSWORD", os.getenv("ODATA_PASSWORD", "password"))
+    username = os.getenv("USERNAME") or os.getenv("ODATA_USERNAME")
+    password = os.getenv("PASSWORD") or os.getenv("ODATA_PASSWORD")
+    if not username or not password:
+        raise ValueError("Backend credentials are not configured")
     return BackendInvoker(base_url, username, password)


### PR DESCRIPTION
## Summary
- ensure backend credentials are loaded from the environment
- error out if credentials are missing
- document the requirement in the README

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `python validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_e_6882902b66f4832b9147ba6e5d621543