### PR TITLE
Add modular OData bridge

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from .router import router
+# import router from the new modular package
+from routes import router
 from fastapi.openapi.utils import get_openapi
 
 app = FastAPI(title="MCP OData Bridge", version="1.0.0")

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,16 @@
+import os
+from dotenv import load_dotenv
+
+
+class Settings:
+    """Load configuration from a .env file or environment."""
+
+    def __init__(self) -> None:
+        load_dotenv()
+        self.dir = os.getenv("DIR")
+        self.db = os.getenv("DB_FILE", "shared.sqlite")
+        self.user = os.getenv("ODATA_USER")
+        self.password = os.getenv("ODATA_PASS")
+
+
+settings = Settings()

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,5 @@
+"""Dynamic Pydantic models generated from OData metadata."""
+
+from .dynamic import build_models
+
+__all__ = ["build_models"]

--- a/models/dynamic.py
+++ b/models/dynamic.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Type
+from datetime import datetime
+from pydantic import BaseModel, Field, create_model
+
+TYPE_MAP = {
+    "Edm.String": str,
+    "Edm.Int32": int,
+    "Edm.Int64": int,
+    "Edm.Decimal": float,
+    "Edm.Boolean": bool,
+    "Edm.DateTime": datetime,
+}
+
+
+def _map_type(edm_type: str, complex_models: Dict[str, Type[BaseModel]]) -> Any:
+    if not edm_type:
+        return str
+    if edm_type in TYPE_MAP:
+        return TYPE_MAP[edm_type]
+    ct_name = edm_type.split(".")[-1]
+    return complex_models.get(ct_name, str)
+
+
+def _build_model(name: str, props: List[Dict[str, Any]], complex_models: Dict[str, Type[BaseModel]]) -> Type[BaseModel]:
+    fields: Dict[str, Any] = {}
+    for prop in props:
+        py_type = _map_type(prop.get("type"), complex_models)
+        default = ...
+        if prop.get("nullable", True):
+            py_type = Optional[py_type]
+            default = None
+        fields[prop["name"]] = (py_type, Field(default, description=prop.get("label")))
+    return create_model(name, **fields)
+
+
+def build_models(metadata: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    complex_models: Dict[str, Type[BaseModel]] = {}
+    for ct in metadata.get("complex_types", []):
+        complex_models[ct["name"]] = _build_model(ct["name"], ct.get("properties", []), complex_models)
+
+    entity_models: Dict[str, Dict[str, Any]] = {}
+    for et in metadata.get("entity_types", []):
+        model = _build_model(et["name"], et.get("properties", []), complex_models)
+        entity_models[et["name"]] = {"model": model, "keys": et.get("keys", [])}
+
+    set_models: Dict[str, Dict[str, Any]] = {}
+    for es in metadata.get("entity_sets", []):
+        et_model = entity_models.get(es["entity_type"])
+        if et_model:
+            set_models[es["name"]] = et_model
+
+    return {"entities": entity_models, "entity_sets": set_models}

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,0 +1,5 @@
+"""API routes for the OData bridge."""
+
+from .odata import router
+
+__all__ = ["router"]

--- a/routes/odata.py
+++ b/routes/odata.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import JSONResponse
+
+from utils.loader import load_metadata, list_services
+from utils.parser import parse_metadata
+from utils.invoker import ODataInvoker
+from models.dynamic import build_models
+
+
+class ServiceContext:
+    def __init__(self, name: str) -> None:
+        xml, base_url = load_metadata(name)
+        self.name = name
+        self.metadata_xml = xml
+        self.base_url = base_url
+        self.parsed = parse_metadata(xml)
+        self.models = build_models(self.parsed)
+        self.invoker = ODataInvoker(base_url)
+
+
+CACHE: Dict[str, ServiceContext] = {}
+
+
+def get_ctx(service: str) -> ServiceContext:
+    ctx = CACHE.get(service)
+    if not ctx:
+        try:
+            ctx = ServiceContext(service)
+        except FileNotFoundError:
+            raise HTTPException(404, "Unknown service")
+        CACHE[service] = ctx
+    return ctx
+
+
+router = APIRouter()
+
+
+@router.get("/services")
+def services() -> Any:
+    return list_services()
+
+
+@router.get("/services/{service}/metadata")
+def metadata(service: str) -> Any:
+    ctx = get_ctx(service)
+    return JSONResponse(content=ctx.metadata_xml)
+
+
+@router.get("/{service}/{entity}")
+def list_entities(
+    service: str,
+    entity: str,
+    filter_: Optional[str] = Query(None, alias="$filter"),
+    top: Optional[int] = Query(None, alias="$top"),
+    skip: Optional[int] = Query(None, alias="$skip"),
+    orderby: Optional[str] = Query(None, alias="$orderby"),
+    expand: Optional[str] = Query(None, alias="$expand"),
+    count: Optional[bool] = Query(None, alias="$count"),
+) -> Any:
+    ctx = get_ctx(service)
+    if entity not in ctx.models.get("entity_sets", {}):
+        raise HTTPException(404, "Unknown entity set")
+    params: Dict[str, Any] = {}
+    if filter_ is not None:
+        params["$filter"] = filter_
+    if top is not None:
+        params["$top"] = top
+    if skip is not None:
+        params["$skip"] = skip
+    if orderby is not None:
+        params["$orderby"] = orderby
+    if expand is not None:
+        params["$expand"] = expand
+    if count is not None:
+        params["$count"] = str(count).lower()
+    return ctx.invoker.get(f"/{service}/{entity}", params)
+
+
+@router.get("/{service}/{entity}({keys})")
+def get_entity(
+    service: str,
+    entity: str,
+    keys: str,
+    expand: Optional[str] = Query(None, alias="$expand"),
+) -> Any:
+    ctx = get_ctx(service)
+    if entity not in ctx.models.get("entity_sets", {}):
+        raise HTTPException(404, "Unknown entity set")
+    params: Dict[str, Any] = {}
+    if expand is not None:
+        params["$expand"] = expand
+    return ctx.invoker.get(f"/{service}/{entity}({keys})", params)
+
+
+@router.post("/invoke")
+def invoke(data: Dict[str, Any]) -> Any:
+    service = data.get("service")
+    path = data.get("path")
+    method = data.get("method", "GET")
+    json_body = data.get("json")
+    if not service or not path:
+        raise HTTPException(400, "service and path required")
+    ctx = get_ctx(service)
+    return ctx.invoker.request(method, f"/{service}{path}", json=json_body)
+
+
+@router.post("/{service}/function/{name}")
+def call_function(service: str, name: str, body: Dict[str, Any]) -> Any:
+    ctx = get_ctx(service)
+    return ctx.invoker.post(f"/{service}/{name}", body)
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,7 @@
+"""Utility helpers for OData bridge."""
+
+from .loader import load_metadata, list_services
+from .parser import parse_metadata
+from .invoker import ODataInvoker
+
+__all__ = ["load_metadata", "list_services", "parse_metadata", "ODataInvoker"]

--- a/utils/invoker.py
+++ b/utils/invoker.py
@@ -1,0 +1,34 @@
+"""HTTP proxy for backend OData calls."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+import requests
+from requests.auth import HTTPBasicAuth
+
+from config import settings
+
+
+class ODataInvoker:
+    def __init__(self, base_url: str) -> None:
+        if not base_url:
+            raise ValueError("Backend base URL missing")
+        self.base_url = base_url.rstrip("/")
+        self.session = requests.Session()
+        if settings.user and settings.password:
+            self.session.auth = HTTPBasicAuth(settings.user, settings.password)
+
+    def request(self, method: str, path: str, params: Optional[Dict[str, Any]] = None, json: Optional[Dict[str, Any]] = None) -> Any:
+        url = f"{self.base_url}{path}"
+        resp = self.session.request(method.upper(), url, params=params, json=json)
+        resp.raise_for_status()
+        try:
+            return resp.json()
+        except ValueError:
+            return resp.text
+
+    def get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        return self.request("GET", path, params=params)
+
+    def post(self, path: str, json: Optional[Dict[str, Any]] = None) -> Any:
+        return self.request("POST", path, json=json)

--- a/utils/loader.py
+++ b/utils/loader.py
@@ -1,0 +1,57 @@
+"""Load OData metadata from file directory or SQLite database."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from typing import List, Tuple
+
+from config import settings
+
+
+def _load_from_file(service_name: str) -> Tuple[str, str]:
+    if not settings.dir:
+        raise FileNotFoundError("Metadata directory not configured")
+    path = os.path.join(settings.dir, f"{service_name}.xml")
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    with open(path, "r", encoding="utf-8") as fh:
+        xml = fh.read()
+    base_url = os.getenv(f"BASE_URL_{service_name.upper()}", "")
+    return xml, base_url
+
+
+def _load_from_db(service_name: str) -> Tuple[str, str]:
+    conn = sqlite3.connect(settings.db)
+    conn.row_factory = sqlite3.Row
+    cur = conn.execute(
+        "SELECT base_url, metadata_raw FROM odata_services WHERE service_name = ?",
+        (service_name,),
+    )
+    row = cur.fetchone()
+    conn.close()
+    if not row:
+        raise FileNotFoundError(f"Service {service_name} not found")
+    return row["metadata_raw"], row["base_url"]
+
+
+def load_metadata(service_name: str) -> Tuple[str, str]:
+    if settings.dir:
+        return _load_from_file(service_name)
+    return _load_from_db(service_name)
+
+
+def list_services() -> List[str]:
+    if settings.dir:
+        if not os.path.isdir(settings.dir):
+            return []
+        return sorted(
+            os.path.splitext(f)[0]
+            for f in os.listdir(settings.dir)
+            if f.lower().endswith(".xml")
+        )
+    conn = sqlite3.connect(settings.db)
+    cur = conn.execute("SELECT service_name FROM odata_services ORDER BY service_name")
+    rows = [r[0] for r in cur.fetchall()]
+    conn.close()
+    return rows

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -1,0 +1,57 @@
+"""Parse OData V2 metadata."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+import xmltodict
+
+
+def _ensure_list(val: Any) -> List[Any]:
+    if not val:
+        return []
+    if isinstance(val, list):
+        return val
+    return [val]
+
+
+def parse_metadata(xml: str) -> Dict[str, Any]:
+    doc = xmltodict.parse(xml)
+    edm = doc.get("edmx:Edmx", doc)
+    ds = edm.get("edmx:DataServices") or edm.get("DataServices")
+    schema = _ensure_list(ds.get("Schema"))[0]
+
+    res: Dict[str, Any] = {"entity_types": [], "entity_sets": [], "functions": [], "associations": [], "navigation": []}
+    res["namespace"] = schema.get("@Namespace")
+
+    for et in _ensure_list(schema.get("EntityType")):
+        keys = [k.get("@Name") for k in _ensure_list(et.get("Key", {}).get("PropertyRef"))]
+        props = []
+        for p in _ensure_list(et.get("Property")):
+            props.append({
+                "name": p.get("@Name"),
+                "type": p.get("@Type"),
+                "nullable": p.get("@Nullable", "true") != "false",
+                "label": p.get("sap:label"),
+            })
+        nav = []
+        for n in _ensure_list(et.get("NavigationProperty")):
+            nav.append({"name": n.get("@Name"), "relationship": n.get("@Relationship"), "to_role": n.get("@ToRole"), "from_role": n.get("@FromRole")})
+        res["entity_types"].append({"name": et.get("@Name"), "keys": keys, "properties": props, "navigation": nav})
+
+    container = schema.get("EntityContainer", {})
+    for es in _ensure_list(container.get("EntitySet")):
+        res["entity_sets"].append({"name": es.get("@Name"), "entity_type": es.get("@EntityType", "").split(".")[-1]})
+
+    for fi in _ensure_list(container.get("FunctionImport")):
+        params = []
+        for p in _ensure_list(fi.get("Parameter")):
+            params.append({"name": p.get("@Name"), "type": p.get("@Type")})
+        res["functions"].append({"name": fi.get("@Name"), "http_method": fi.get("@m:HttpMethod") or fi.get("@HttpMethod", "GET"), "parameters": params})
+
+    for assoc in _ensure_list(schema.get("Association")):
+        res["associations"].append({"name": assoc.get("@Name")})
+
+    for aset in _ensure_list(container.get("AssociationSet")):
+        res["navigation"].append({"name": aset.get("@Name")})
+
+    return res


### PR DESCRIPTION
## Summary
- add config loader for env variables
- implement metadata loader for file/DB sources
- parse OData metadata and build dynamic pydantic models
- proxy routes for listing entity sets, getting entities and invoking functions
- update main to use new modular router

## Testing
- `python validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_e_68833a6a509c832ba8ddddde92160c0a