### PR TITLE
Make package executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ service.
 
 4. Run the server:
    ```bash
-   uvicorn app.main:app
+   python path/to/openapi-odata
    ```
+   The package can still be started manually with Uvicorn using `uvicorn app.main:app` if preferred.
 
 The `/openapi.json` endpoint exposes the combined OpenAPI specification while `/tools/{service}` returns tool metadata for a single service.

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+"""OpenAPI OData bridge package."""

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,11 @@
+import uvicorn
+from app.main import app
+
+
+def main() -> None:
+    """Launch the FastAPI server."""
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expose package entry point via `__main__.py`
- mark project directory as a package
- document running the server with `python path/to/openapi-odata`

## Testing
- `python openapi-odata/validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_e_68835de8d164832bab5b708836c31ce7