### PR TITLE
Fix docs endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,6 @@ service.
    ```
    The package can still be started manually with Uvicorn using `uvicorn app.main:app` if preferred.
 
-The `/openapi.json` endpoint exposes the combined OpenAPI specification while `/tools/{service}` returns tool metadata for a single service.
+The `/docs` path serves an interactive Swagger UI while `/openapi.json` exposes
+the combined OpenAPI specification. The `/tools/{service}` endpoint returns tool
+metadata for a single service.

--- a/app/main.py
+++ b/app/main.py
@@ -29,7 +29,7 @@ def _convert_to_openapi_30(schema: Dict[str, Any]) -> Dict[str, Any]:
 app = FastAPI(
     title="MCP OData Bridge",
     version="1.0.0",
-    openapi_url=None,  # disable default route so we can override
+    openapi_url="/openapi.json",  # expose schema for docs
 )
 app.add_middleware(
     CORSMiddleware,
@@ -40,7 +40,10 @@ app.add_middleware(
 app.include_router(router)
 
 
-@app.get("/openapi.json", include_in_schema=False)
-def openapi_schema():
+def custom_openapi() -> Dict[str, Any]:
+    """Return an OpenAPI 3.0 compatible schema."""
     schema = get_openapi(title=app.title, version=app.version, routes=app.routes)
     return _convert_to_openapi_30(schema)
+
+
+app.openapi = custom_openapi


### PR DESCRIPTION
## Summary
- expose the schema at `/openapi.json`
- register a custom `app.openapi` so FastAPI docs work
- document the `/docs` route in README

## Testing
- `pip install -r requirements.txt`
- `python validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_e_688366e93d00832b808b9e52a5a35c84