### PR TITLE
Add MCP mode entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,16 @@ service.
 The `/docs` path serves an interactive Swagger UI while `/openapi.json` exposes
 the combined OpenAPI specification. The `/tools/{service}` endpoint returns tool
 metadata for a single service.
+
+## Running in MCP Mode
+
+The bridge can also run in MCP-compatible mode where it communicates over
+`stdin`/`stdout` using JSON-RPC messages.
+
+```bash
+# MCP Mode
+python mcp_main.py
+```
+
+In this mode the process expects JSON-RPC requests on `stdin` and writes
+responses to `stdout`.

--- a/mcp_main.py
+++ b/mcp_main.py
@@ -1,0 +1,52 @@
+import sys
+import json
+import threading
+import uvicorn
+from app.main import app
+
+
+def run_server() -> None:
+    """Start the FastAPI server."""
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+def mcp_loop() -> None:
+    """Process JSON-RPC messages from stdin and write responses to stdout."""
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if (
+            msg.get("jsonrpc") == "2.0"
+            and msg.get("method") == "initialize"
+        ):
+            resp = {
+                "jsonrpc": "2.0",
+                "id": msg.get("id"),
+                "result": {
+                    "serverInfo": {
+                        "name": "MCP OData Bridge",
+                        "version": "1.0.0",
+                    },
+                    "capabilities": {
+                        "odata": True,
+                        "version": "1.0",
+                    },
+                },
+            }
+            print(json.dumps(resp), flush=True)
+
+
+def main() -> None:
+    """Run the server alongside the MCP loop."""
+    thread = threading.Thread(target=run_server, daemon=True)
+    thread.start()
+    mcp_loop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `mcp_main.py` optional entrypoint for MCP protocol
- document MCP mode in README

## Testing
- `python -m py_compile mcp_main.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `pip install httpx`
- `python validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_e_68837598a83c832bb4d0a500a95dce71