### PR TITLE
Fix JSON-RPC initialize response

### DIFF
--- a/jsonrpc_server/__init__.py
+++ b/jsonrpc_server/__init__.py
@@ -4,6 +4,16 @@ import logging
 from typing import Optional
 from jsonrpcserver import method, dispatch, result
 
+CAPABILITIES = {
+    "services": {},
+    "metadata": {},
+    "get_entity": {},
+    "list_entities": {},
+    "invoke": {},
+    "call_function": {},
+}
+
+from openapi_server import app
 from openapi_server.routes.odata import (
     services as _services,
     metadata as _metadata,
@@ -17,7 +27,13 @@ from openapi_server.routes.odata import (
 @method
 def initialize() -> result.Result:
     """Handle the JSON-RPC initialize request."""
-    return result.Success({"capabilities": {}})
+    return result.Success(
+        {
+            "protocolVersion": "2.0",
+            "serverInfo": {"name": app.title, "version": app.version},
+            "capabilities": CAPABILITIES,
+        }
+    )
 
 
 @method


### PR DESCRIPTION
## Summary
- include server name/version and supported capabilities in `initialize`
- expose protocol version for MCP clients

## Testing
- `python -m py_compile jsonrpc_server/__init__.py`
- `python -m py_compile openapi_server/__init__.py`
- `python main.py --mode jsonrpc <<'EOF'
{"jsonrpc": "2.0", "id": 1, "method": "initialize"}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6883be0cc398832bb3c8349fecab5d99