### PR TITLE
Support MCP-style tools/call

### DIFF
--- a/jsonrpc_server/__init__.py
+++ b/jsonrpc_server/__init__.py
@@ -160,10 +160,10 @@ def list_tools() -> result.Result:
 
 
 @method(name="tools/call")
-def call_tool(params: Dict[str, Any]) -> result.Result:
+def call_tool(name: str, arguments: Optional[Dict[str, Any]] = None) -> result.Result:
     """Execute one of the available tools using MCP format."""
-    name = params.get("name")
-    arguments = params.get("arguments", {}) or {}
+    if arguments is None:
+        arguments = {}
 
     if not name:
         return result.Error(code=400, message="Tool name required")


### PR DESCRIPTION
## Summary
- update `tools/call` JSON-RPC handler to take `name` and `arguments`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883cda31118832b97ba0c1f2e7eeaac