### PR TITLE
Add logging for JSON-RPC and HTTP calls

### DIFF
--- a/jsonrpc_server/__init__.py
+++ b/jsonrpc_server/__init__.py
@@ -207,11 +207,14 @@ def call_tool(name: str, arguments: Optional[Dict[str, Any]] = None) -> result.R
 
 def serve() -> None:
     """Run the JSON-RPC server reading from stdin and writing to stdout."""
-    logging.basicConfig(stream=sys.stderr, level=logging.CRITICAL)
+    logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+    logger = logging.getLogger(__name__)
     for line in sys.stdin:
         line = line.strip()
         if not line:
             continue
+        logger.info("Request: %s", line)
         response = dispatch(line)
         if response:
+            logger.info("Response: %s", response)
             print(response, flush=True)

--- a/tools/invoker.py
+++ b/tools/invoker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Optional
+import logging
 import requests
 from requests.auth import HTTPBasicAuth
 
@@ -17,10 +18,22 @@ class ODataInvoker:
         self.session = requests.Session()
         if settings.user and settings.password:
             self.session.auth = HTTPBasicAuth(settings.user, settings.password)
+        self.logger = logging.getLogger(__name__)
 
-    def request(self, method: str, path: str, params: Optional[Dict[str, Any]] = None, json: Optional[Dict[str, Any]] = None) -> Any:
+    def request(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+    ) -> Any:
         url = f"{self.base_url}{path}"
+        self.logger.info(
+            "HTTP %s %s params=%s json=%s", method.upper(), url, params, json
+        )
         resp = self.session.request(method.upper(), url, params=params, json=json)
+        self.logger.info("Status %s", resp.status_code)
+        self.logger.debug("Body %s", resp.text)
         resp.raise_for_status()
         try:
             return resp.json()


### PR DESCRIPTION
## Summary
- log inbound and outbound JSON-RPC messages
- log outgoing HTTP requests and responses from the OData invoker

## Testing
- `python -m py_compile jsonrpc_server/__init__.py tools/invoker.py`
- `pip install --user -r requirements.txt`
- `env DIR=. python main.py --mode jsonrpc <<'EOF'
{"jsonrpc": "2.0", "id": 2, "method": "metadata", "params": {"service": "sample_metadata"}}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6883dbea10d0832b9f822ad12fb494d0