### PR TITLE
Fix initialize parameter handling

### DIFF
--- a/jsonrpc_server/__init__.py
+++ b/jsonrpc_server/__init__.py
@@ -97,8 +97,24 @@ TOOLS: List[Dict[str, Dict]] = [
 
 
 @method
-def initialize() -> result.Result:
-    """Handle the JSON-RPC initialize request."""
+def initialize(
+    protocolVersion: Optional[str] = None,
+    capabilities: Optional[Dict[str, Any]] = None,
+    clientInfo: Optional[Dict[str, Any]] = None,
+    **_kwargs: Any,
+) -> result.Result:
+    """Handle the JSON-RPC initialize request.
+
+    Parameters are accepted for compatibility with clients that send them
+    during the initialize handshake. They are not currently used, but the
+    presence of these optional parameters prevents ``InvalidParams`` errors
+    from the dispatcher.
+    """
+
+    # Ignore the requested protocol version and always respond with the
+    # standard version supported by this server.
+    _ = (protocolVersion, capabilities, clientInfo, _kwargs)
+
     return result.Success(
         {
             "protocolVersion": "2024-11-05",


### PR DESCRIPTION
## Summary
- let JSON-RPC `initialize` accept optional parameters so requests with params succeed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883e1652abc832ba66c5b9213ddd028