### PR TITLE
Add configurable backend base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ mode: http  # "http", "jsonrpc", or "both"
 port: 8000  # HTTP server port
 # dir: ./metadata
 # db_file: shared.sqlite
+# base_url: https://sapes5.sapdevcenter.com/sap/opu/odata/sap
 # odata_user: username
 # odata_pass: password
 ```
 
-The `DIR` variable points at a directory containing service metadata XML files. Alternatively set `DB_FILE` to use a SQLite database. Credentials for backend requests can be provided via `ODATA_USER` and `ODATA_PASS`.
+The `DIR` variable points at a directory containing service metadata XML files. Alternatively set `DB_FILE` to use a SQLite database. Credentials for backend requests can be provided via `ODATA_USER` and `ODATA_PASS`. `BASE_URL` sets the default OData endpoint used for backend requests when a service metadata file does not specify one.
 
 ## Running
 

--- a/config.py
+++ b/config.py
@@ -14,5 +14,6 @@ class Settings:
         self.db = os.getenv("DB_FILE", cfg.get("db_file", "shared.sqlite"))
         self.user = os.getenv("ODATA_USER", cfg.get("odata_user"))
         self.password = os.getenv("ODATA_PASS", cfg.get("odata_pass"))
+        self.base_url = os.getenv("BASE_URL", cfg.get("base_url"))
 
 settings = Settings()

--- a/config.yaml
+++ b/config.yaml
@@ -4,5 +4,6 @@ mode: http
 port: 8000
 # dir: ./metadata
 # db_file: shared.sqlite
+# base_url: https://sapes5.sapdevcenter.com/sap/opu/odata/sap
 # odata_user: username
 # odata_pass: password

--- a/openapi_server/routes/odata.py
+++ b/openapi_server/routes/odata.py
@@ -8,6 +8,7 @@ from fastapi.responses import JSONResponse
 from tools.loader import load_metadata, list_services
 from tools.parser import parse_metadata
 from tools.invoker import ODataInvoker
+from config import settings
 from models.dynamic import build_models
 
 
@@ -53,10 +54,10 @@ class ServiceContext:
         xml, base_url = load_metadata(name)
         self.name = name
         self.metadata_xml = xml
-        self.base_url = base_url
+        self.base_url = base_url or settings.base_url
         self.parsed = parse_metadata(xml)
         self.models = build_models(self.parsed)
-        self.invoker = ODataInvoker(base_url)
+        self.invoker = ODataInvoker(self.base_url)
         self.key_types = self._extract_key_types()
 
     def _extract_key_types(self) -> Dict[str, Dict[str, str]]:

--- a/tools/invoker.py
+++ b/tools/invoker.py
@@ -11,10 +11,11 @@ from config import settings
 
 
 class ODataInvoker:
-    def __init__(self, base_url: str) -> None:
-        if not base_url:
+    def __init__(self, base_url: Optional[str] = None) -> None:
+        base = base_url or settings.base_url
+        if not base:
             raise ValueError("Backend base URL missing")
-        self.base_url = base_url.rstrip("/")
+        self.base_url = base.rstrip("/")
         self.session = requests.Session()
         if settings.user and settings.password:
             self.session.auth = HTTPBasicAuth(settings.user, settings.password)


### PR DESCRIPTION
## Summary
- make base URL configurable in `config.py`
- default to the configured `BASE_URL` when creating `ODataInvoker`
- use the default in `ServiceContext`
- document the new configuration option

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883ebcf8124832b8a892fc14088df38