### PR TITLE
Remove env variable config overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install -r requirements.txt
 
 ## Configuration
 
-Configuration is loaded from `config.yaml` if present and can be overridden with environment variables.
+Configuration is loaded from `config.yaml`. Environment variables are ignored.
 
 Example `config.yaml`:
 
@@ -26,13 +26,12 @@ port: 8000  # HTTP server port
 # odata_pass: password
 ```
 
-The `DIR` variable points at a directory containing service metadata XML files. Alternatively set `DB_FILE` to use a SQLite database. Credentials for backend requests can be provided via `ODATA_USER` and `ODATA_PASS`. `BASE_URL` sets the default OData endpoint used for backend requests when a service metadata file does not specify one.
+Set `dir` to point at a directory containing service metadata XML files. Alternatively set `db_file` to use a SQLite database. Credentials for backend requests can be provided via `odata_user` and `odata_pass`. `base_url` sets the default OData endpoint used for backend requests when a service metadata file does not specify one.
 
 ## Running
 
-Use `main.py` with the `--mode` option or set `MODE` in the environment. The
-HTTP port can be configured with the `--port` option or `PORT` environment
-variable.
+Use `main.py` with the `--mode` option to start the server. The HTTP port can
+be changed with the `--port` option.
 
 ### HTTP Mode
 

--- a/config.py
+++ b/config.py
@@ -2,18 +2,20 @@ import os
 import yaml
 
 class Settings:
-    """Load configuration from YAML file and environment variables."""
+    """Load configuration exclusively from a YAML file."""
+
     def __init__(self, path: str = "config.yaml") -> None:
         cfg = {}
         if os.path.exists(path):
             with open(path, "r", encoding="utf-8") as fh:
                 cfg = yaml.safe_load(fh) or {}
-        self.mode = os.getenv("MODE", cfg.get("mode", "http"))
-        self.port = int(os.getenv("PORT", cfg.get("port", 8000)))
-        self.dir = os.getenv("DIR", cfg.get("dir"))
-        self.db = os.getenv("DB_FILE", cfg.get("db_file", "shared.sqlite"))
-        self.user = os.getenv("ODATA_USER", cfg.get("odata_user"))
-        self.password = os.getenv("ODATA_PASS", cfg.get("odata_pass"))
-        self.base_url = os.getenv("BASE_URL", cfg.get("base_url"))
+
+        self.mode = cfg.get("mode", "http")
+        self.port = int(cfg.get("port", 8000))
+        self.dir = cfg.get("dir")
+        self.db = cfg.get("db_file", "shared.sqlite")
+        self.user = cfg.get("odata_user")
+        self.password = cfg.get("odata_pass")
+        self.base_url = cfg.get("base_url")
 
 settings = Settings()

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 # Default configuration for MCP OData bridge
+# All settings are read from this file; environment variables are ignored.
 mode: http
 # port used for HTTP server
 port: 8000

--- a/fetch_metadata.py
+++ b/fetch_metadata.py
@@ -2,13 +2,15 @@ import argparse
 import os
 import requests
 
+from config import settings
+
 
 def main():
     parser = argparse.ArgumentParser(description="Download OData service metadata")
     parser.add_argument("service", help="Name of the OData service")
     parser.add_argument(
         "--base-url",
-        default=os.getenv("ODATA_BASE_URL", "http://example.com"),
+        default=settings.base_url or "http://example.com",
         help="Base URL of the OData system",
     )
     parser.add_argument(
@@ -18,12 +20,12 @@ def main():
     )
     parser.add_argument(
         "--username",
-        default=os.getenv("ODATA_USER", "user"),
+        default=settings.user or "user",
         help="Basic auth username",
     )
     parser.add_argument(
         "--password",
-        default=os.getenv("ODATA_PASS", "password"),
+        default=settings.password or "password",
         help="Basic auth password",
     )
     args = parser.parse_args()

--- a/tools/loader.py
+++ b/tools/loader.py
@@ -17,8 +17,7 @@ def _load_from_file(service_name: str) -> Tuple[str, str]:
         raise FileNotFoundError(path)
     with open(path, "r", encoding="utf-8") as fh:
         xml = fh.read()
-    base_url = os.getenv(f"BASE_URL_{service_name.upper()}", "")
-    return xml, base_url
+    return xml, ""
 
 
 def _load_from_db(service_name: str) -> Tuple[str, str]:


### PR DESCRIPTION
## Summary
- load all settings exclusively from `config.yaml`
- drop environment variable lookup in loader and helper script
- update docs and sample config

## Testing
- `pip install -r requirements.txt`
- `python main.py --mode jsonrpc <<'EOF'
{"jsonrpc": "2.0", "id": 1, "method": "services"}
EOF`
- `python main.py --mode http --port 8000 & sleep 5; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_6883f8737bd0832b9ab43e65e1dea05b