### PR TITLE
Add JSON-RPC file logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Runs a JSON-RPC 2.0 server that reads requests from `stdin` and writes responses
 python main.py --mode jsonrpc
 ```
 
+Logs of all requests and responses are written to `jsonrpc_server/jsonrpc.log`.
+
 Example request/response:
 
 ```bash

--- a/jsonrpc_server/__init__.py
+++ b/jsonrpc_server/__init__.py
@@ -1,6 +1,7 @@
 """Simple JSON-RPC 2.0 server exposing OData endpoints."""
 import sys
 import logging
+from pathlib import Path
 from typing import Optional, Dict, List, Any
 from jsonrpcserver import method, dispatch, result
 from starlette.responses import Response
@@ -320,7 +321,15 @@ def call_tool(name: str, arguments: Optional[Dict[str, Any]] = None) -> result.R
 
 def serve() -> None:
     """Run the JSON-RPC server reading from stdin and writing to stdout."""
-    logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+    log_file = Path(__file__).with_name("jsonrpc.log")
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        handlers=[
+            logging.StreamHandler(sys.stderr),
+            logging.FileHandler(log_file, mode="a"),
+        ],
+    )
     logger = logging.getLogger(__name__)
     for line in sys.stdin:
         line = line.strip()


### PR DESCRIPTION
## Summary
- add logging to file for JSON-RPC requests and responses
- document logging file in README

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `printf '%s\n' '{"jsonrpc": "2.0", "id": 1, "method": "services"}' | python main.py --mode jsonrpc`

------
https://chatgpt.com/codex/tasks/task_e_688400a3aca8832b8d610cd9cecc60d5