### PR TITLE
Add CopilotStudio client loading from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+environmentId="<YOUR_ENVIRONMENT_ID>"
+agentIdentifier="<YOUR_AGENT_IDENTIFIER>"
+tenantId="<YOUR_TENANT_ID>"
+appClientId="<YOUR_APP_CLIENT_ID>"

--- a/README.md
+++ b/README.md
@@ -80,3 +80,17 @@ printf '%s\n' '{"jsonrpc": "2.0", "id": 1, "method": "services"}' | python main.
 # Both modes example
 python main.py --mode both --port 8000
 ```
+
+## CopilotStudio Client Environment
+
+The optional `CopilotStudioClient` reads configuration values from a `.env` file.
+Create a file named `.env` in the project root and provide the following variables:
+
+```
+environmentId="<YOUR_ENVIRONMENT_ID>"
+agentIdentifier="<YOUR_AGENT_IDENTIFIER>"
+tenantId="<YOUR_TENANT_ID>"
+appClientId="<YOUR_APP_CLIENT_ID>"
+```
+
+These values are used when initializing `CopilotStudioClient`.

--- a/copilot_client.py
+++ b/copilot_client.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import os
+from dotenv import load_dotenv
+
+class CopilotStudioClient:
+    """Simple client loading credentials from a .env file."""
+
+    def __init__(self) -> None:
+        # Load variables from .env if present
+        load_dotenv()
+        self.environment_id = os.getenv("environmentId")
+        self.agent_identifier = os.getenv("agentIdentifier")
+        self.tenant_id = os.getenv("tenantId")
+        self.app_client_id = os.getenv("appClientId")
+
+        missing = [
+            name
+            for name, val in [
+                ("environmentId", self.environment_id),
+                ("agentIdentifier", self.agent_identifier),
+                ("tenantId", self.tenant_id),
+                ("appClientId", self.app_client_id),
+            ]
+            if not val
+        ]
+        if missing:
+            raise ValueError(f"Missing environment variables: {', '.join(missing)}")
+
+    def __repr__(self) -> str:
+        return (
+            "CopilotStudioClient("
+            f"environment_id={self.environment_id}, "
+            f"agent_identifier={self.agent_identifier}, "
+            f"tenant_id={self.tenant_id}, "
+            f"app_client_id={self.app_client_id})"
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyyaml
 jsonrpcserver
 requests
 xmltodict
+python-dotenv


### PR DESCRIPTION
## Summary
- add `CopilotStudioClient` which loads credentials from a `.env` file
- include a sample `.env.example`
- update README with usage instructions for the client
- add `python-dotenv` to requirements

## Testing
- `python -m py_compile copilot_client.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `pip install httpx`
- `pip install openapi-spec-validator`

------
https://chatgpt.com/codex/tasks/task_e_6884a71f1f00832bbc158fbf761ce318