### PR TITLE
Update call_tool response to MCP format

### DIFF
--- a/jsonrpc_server/__init__.py
+++ b/jsonrpc_server/__init__.py
@@ -313,7 +313,9 @@ def call_tool(name: str, arguments: Optional[Dict[str, Any]] = None) -> result.R
     try:
         res = func()
         print(f"DEBUG: Got result: {res}", file=sys.stderr)
-        return result.Success({"content": res, "contentType": "application/json"})
+        return result.Success(
+            {"content": [{"type": "text", "text": str(res)}]}
+        )
     except Exception as e:
         print(f"DEBUG: Error occurred: {e}", file=sys.stderr)
         return result.Error(code=500, message=str(e))


### PR DESCRIPTION
## Summary
- update `jsonrpc_server.call_tool` to return MCP style result content

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688521e1e588832b964d7bdc0808c6d7